### PR TITLE
Fixed Issue #366

### DIFF
--- a/src/sass/modal.sass
+++ b/src/sass/modal.sass
@@ -8,6 +8,7 @@
   a:hover
     text-decoration: none
 .modal-dialog
+  padding: 5%
   @extend .col-md-6
   @extend .col-md-offset-3
 .modal-body


### PR DESCRIPTION
Initially, When triggering Login model There was no left & right padding wrt browser window when screen size was xs or sm.
I fixed it by adding 5% padding to .modal-dialog class
Kindly review the pull request.

Regards
Divyanshu Rawat